### PR TITLE
feat:m5stack-Bluetooth

### DIFF
--- a/Assets/Scenes/main.unity
+++ b/Assets/Scenes/main.unity
@@ -536,6 +536,66 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _velocity: {x: 0, y: 0, z: 8}
   obj: {fileID: 713788810}
+--- !u!1 &739072886
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 739072887}
+  - component: {fileID: 739072889}
+  - component: {fileID: 739072888}
+  m_Layer: 0
+  m_Name: M5stack_Evnet
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &739072887
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 739072886}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &739072888
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 739072886}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00cd15871f43f4598a90975168bf12ef, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  serialHandler: {fileID: 739072889}
+--- !u!114 &739072889
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 739072886}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9c496f401bbf4472c872df9879e20171, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  portName: /dev/cu.m5stack_shibakari
+  baudRate: 115200
 --- !u!1 &838274065 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5118948140946602063, guid: c462be36e62ef4cfc98cba70c7ffec15, type: 3}
@@ -1274,3 +1334,4 @@ SceneRoots:
   - {fileID: 1427203981}
   - {fileID: 198832279}
   - {fileID: 1059184519}
+  - {fileID: 739072887}

--- a/Assets/Scripts/SerialHandler.cs
+++ b/Assets/Scripts/SerialHandler.cs
@@ -1,0 +1,91 @@
+using UnityEngine;
+using System.IO.Ports;
+using System.Threading;
+
+public class SerialHandler : MonoBehaviour
+{
+    public delegate void SerialDataReceivedEventHandler(string message);
+    public event SerialDataReceivedEventHandler OnDataReceived;
+
+    public string portName = "/dev/cu.m5stack_shibakari";
+    public int baudRate = 115200;
+
+    private SerialPort serialPort;
+
+    private void Awake()
+    {
+        Open();
+    }
+
+    private void OnDestroy()
+    {
+        Close();
+    }
+
+    private void Open()
+    {
+        try
+        {
+            serialPort = new SerialPort(portName, baudRate);
+            serialPort.Open();
+            serialPort.DiscardInBuffer();
+            serialPort.DiscardOutBuffer();
+        }
+        catch (System.Exception e)
+        {
+            Debug.LogError("Failed to open serial port: " + e.Message);
+            return;
+        }
+
+        if (serialPort.IsOpen)
+        {
+            Debug.Log("Serial port opened successfully.");
+        }
+        else
+        {
+            Debug.LogError("Failed to open serial port.");
+        }
+
+        // Start reading data from the serial port in a separate thread
+        Thread thread = new Thread(Read);
+        thread.Start();
+    }
+
+    private void Close()
+    {
+        if (serialPort != null && serialPort.IsOpen)
+        {
+            serialPort.Close();
+            serialPort.Dispose();
+            Debug.Log("Serial port closed.");
+        }
+    }
+
+    private void Read()
+    {
+        while (serialPort != null && serialPort.IsOpen)
+        {
+            try
+            {
+                string message = serialPort.ReadLine();
+                OnDataReceived?.Invoke(message);
+            }
+            catch (System.Exception e)
+            {
+                Debug.LogError("Error reading from serial port: " + e.Message);
+            }
+        }
+    }
+
+    public void Write(string message)
+    {
+        try
+        {
+            serialPort.Write(message);
+        }
+        catch (System.Exception e)
+        {
+            Debug.LogError("Error writing to serial port: " + e.Message);
+        }
+    }
+}

--- a/Assets/Scripts/SerialHandler.cs.meta
+++ b/Assets/Scripts/SerialHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c496f401bbf4472c872df9879e20171
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SerialReceive.cs
+++ b/Assets/Scripts/SerialReceive.cs
@@ -1,0 +1,76 @@
+using UnityEngine;
+
+public class SerialReceive : MonoBehaviour
+{
+    public SerialHandler serialHandler;
+
+    private float gyroX, gyroY, gyroZ; // 加速度
+    private float accX, accY, accZ; // ジャイロ
+    private float pitch, roll, yaw; // 磁気
+    private float temp; // 温度
+
+    void Start()
+    {
+        serialHandler.OnDataReceived += OnDataReceived;
+    }
+
+    // Ardino側のプログラムによって変更が必要
+    void OnDataReceived(string message)
+    {
+        // Example of received message:
+        // "Accel: 0.00, 0.00, 0.00\tGyro: 0.00, 0.00, 0.00\tMag: 0.00, 0.00, 0.00\tTemp: 0.00"
+
+        try
+        {
+            // Split the message into sections based on tabs
+            string[] sections = message.Split('\t');
+            if (sections.Length >= 4)
+            {
+                // 加速度のデータを切り離し，それぞれの変数に代入
+                string[] accelData = sections[0].Substring(7).Split(',');
+                if (accelData.Length == 3)
+                {
+                    accX = float.Parse(accelData[0]);
+                    accY = float.Parse(accelData[1]);
+                    accZ = float.Parse(accelData[2]);
+                }
+
+                // ジャイロのデータを切り離し，それぞれの変数に代入
+                string[] gyroData = sections[1].Substring(6).Split(',');
+                if (gyroData.Length == 3)
+                {
+                    gyroX = float.Parse(gyroData[0]);
+                    gyroY = float.Parse(gyroData[1]);
+                    gyroZ = float.Parse(gyroData[2]);
+                }
+
+                // 磁気のデータを切り離し，それぞれの変数に代入
+                string[] magData = sections[2].Substring(5).Split(',');
+                if (magData.Length == 3)
+                {
+                    pitch = float.Parse(magData[0]);
+                    roll = float.Parse(magData[1]);
+                    yaw = float.Parse(magData[2]);
+                }
+
+                // 温度のデータを切り離し，それぞれの変数に代入
+                string tempData = sections[3].Substring(6);
+                temp = float.Parse(tempData);
+
+                // Debug.Logへの表示
+                Debug.Log($"Received accel data: {accX}, {accY}, {accZ}");
+                Debug.Log($"Received gyro data: {gyroX}, {gyroY}, {gyroZ}");
+                Debug.Log($"Received mag data: {pitch}, {roll}, {yaw}");
+                Debug.Log($"Received temp data: {temp}");
+            }
+            else
+            {
+                Debug.LogWarning("Insufficient data sections after splitting.");
+            }
+        }
+        catch (System.Exception e)
+        {
+            Debug.LogError($"Error parsing data: {e.Message}");
+        }
+    }
+}

--- a/Assets/Scripts/SerialReceive.cs.meta
+++ b/Assets/Scripts/SerialReceive.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 00cd15871f43f4598a90975168bf12ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -157,7 +157,8 @@ PlayerSettings:
   resetResolutionOnWindowResize: 0
   androidSupportedAspectRatio: 1
   androidMaxAspectRatio: 2.1
-  applicationIdentifier: {}
+  applicationIdentifier:
+    Standalone: com.DefaultCompany.shibakari
   buildNumber:
     Standalone: 0
     VisionOS: 0
@@ -838,7 +839,7 @@ PlayerSettings:
   embeddedLinuxEnableGamepadInput: 1
   hmiLogStartupTiming: 0
   hmiCpuConfiguration: 
-  apiCompatibilityLevel: 6
+  apiCompatibilityLevel: 3
   activeInputHandler: 0
   windowsGamepadBackendHint: 0
   cloudProjectId: 


### PR DESCRIPTION
## 概要
m5stackのBluetoothを使用した値の送信
　・加速度，ジャイロ，磁気，温度のデータをデバッグログに表示

## 関連するIssue
芝刈りを振った際のオブジェクトの動きをこのコードからの値に置き換えたい

## 変更内容
二つの関連ファイルの追加
　・SerialReceive：受信したデータの切り離し変換するコード
　・SerialHandler：通信の開始，終了を行うコード

## 動画
https://github.com/CC-Circle/Shibakari/assets/104050688/5623dbdf-ac51-4ac8-9a52-a42c0aa1c903

## テスト
他のオブジェクトを無効化した状態でのdebuglogの確認
　・一回通信がきれるとBluetoothの設定を一度削除し，接続し直す必要あり

## その他
基本的にセンサー班が使用するため，無効化しています．