### PR TITLE
add-scencer-move

### DIFF
--- a/Assets/Scenes/main.unity
+++ b/Assets/Scenes/main.unity
@@ -140,7 +140,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &198832277
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -207,7 +207,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &205033764
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -410,7 +410,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!108 &705507994
 Light:
   m_ObjectHideFlags: 0
@@ -504,7 +504,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &713788811
 Transform:
   m_ObjectHideFlags: 0
@@ -582,9 +582,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   serialHandler: {fileID: 739072889}
-  gyroX: 0
-  gyroY: 0
-  gyroZ: 0
 --- !u!114 &739072889
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -597,7 +594,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9c496f401bbf4472c872df9879e20171, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  portName: /dev/cu.m5stack_shibakari
   baudRate: 115200
 --- !u!1 &838274065 stripped
 GameObject:
@@ -609,7 +605,7 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5863695923085891535, guid: c462be36e62ef4cfc98cba70c7ffec15, type: 3}
   m_PrefabInstance: {fileID: 5457455370683388638}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &838274067
+--- !u!114 &838274072
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -618,25 +614,10 @@ MonoBehaviour:
   m_GameObject: {fileID: 838274065}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ff2957cb8bfda40bbb9b746ac9c850a0, type: 3}
+  m_Script: {fileID: 11500000, guid: 337e4f7edfbd340e485fd8026fea4224, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  moveSpeed: 5
---- !u!114 &838274071
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 838274065}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2731141012e544042bb327d6e45424a3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  sensitivity: 1
-  _velocity: {x: 0, y: 0, z: 1}
-  obj: {fileID: 713788810}
+  serialReceive: {fileID: 739072888}
 --- !u!1 &866633914
 GameObject:
   m_ObjectHideFlags: 0
@@ -655,7 +636,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!65 &866633915
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -753,6 +734,7 @@ GameObject:
   - component: {fileID: 963194228}
   - component: {fileID: 963194227}
   - component: {fileID: 963194226}
+  - component: {fileID: 963194229}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -828,12 +810,24 @@ Transform:
   m_GameObject: {fileID: 963194225}
   serializedVersion: 2
   m_LocalRotation: {x: -0.03780074, y: -0.0009030866, z: 0.000034153458, w: -0.9992849}
-  m_LocalPosition: {x: -0.3719021, y: 16.30897, z: -28.05075}
+  m_LocalPosition: {x: -0.3719021, y: 16.30897, z: -24.71}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 713788811}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &963194229
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e1d71fc01a6dd44e6afdd4051344c6e2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1006789003
 GameObject:
   m_ObjectHideFlags: 0
@@ -850,7 +844,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &1006789004
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -944,7 +938,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!136 &1386050256
 CapsuleCollider:
   m_ObjectHideFlags: 0
@@ -1051,7 +1045,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &1427203978
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1153,7 +1147,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!65 &1969147293
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -1318,10 +1312,7 @@ PrefabInstance:
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 5118948140946602063, guid: c462be36e62ef4cfc98cba70c7ffec15, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 838274067}
-    - targetCorrespondingSourceObject: {fileID: 5118948140946602063, guid: c462be36e62ef4cfc98cba70c7ffec15, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 838274071}
+      addedObject: {fileID: 838274072}
   m_SourcePrefab: {fileID: 100100000, guid: c462be36e62ef4cfc98cba70c7ffec15, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:

--- a/Assets/Scripts/CutMove.cs
+++ b/Assets/Scripts/CutMove.cs
@@ -1,0 +1,52 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CutMove : MonoBehaviour
+{
+    public SerialReceive serialReceive; // Inspectorでセットするか、動的に取得
+    private int leftRightCount = 0; // 左右の振りカウント
+    private bool wasLeft = false; // 前回が左だったか
+
+    void Update()
+    {
+        Debug.Log(serialReceive.Flag);
+        // 現在の位置を取得
+        Vector3 currentPosition = transform.position;
+
+        if (serialReceive.Flag == 1)
+        {
+            currentPosition.x = -20;
+            if (!wasLeft) // 前回が左でなければカウントを増加
+            {
+                leftRightCount++;
+                wasLeft = true;
+            }
+        }
+        else if (serialReceive.Flag == 2)
+        {
+            currentPosition.x = 20;
+            if (wasLeft) // 前回が左だったらカウントを増加
+            {
+                leftRightCount++;
+                wasLeft = false;
+            }
+        }
+        else
+        {
+            // x値だけをリセットした位置を取得
+            currentPosition.x = 0;
+        }
+
+        // 新しい位置を設定
+        transform.position = currentPosition;
+
+        // 左右に一回ずつ振ったら前進
+        if (leftRightCount >= 2)
+        {
+            currentPosition.z += 10; // 前進させる
+            transform.position = currentPosition;
+            leftRightCount = 0; // カウントをリセット
+        }
+    }
+}

--- a/Assets/Scripts/CutMove.cs.meta
+++ b/Assets/Scripts/CutMove.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 337e4f7edfbd340e485fd8026fea4224
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SerialHandler.cs
+++ b/Assets/Scripts/SerialHandler.cs
@@ -7,7 +7,10 @@ public class SerialHandler : MonoBehaviour
     public delegate void SerialDataReceivedEventHandler(string message);
     public event SerialDataReceivedEventHandler OnDataReceived;
 
-    public string portName = "/dev/cu.m5stack_shibakari";
+    // 1人対戦用のポート（基本はこっち）
+    private string portName = "/dev/cu.m5stack_shibakari_1";
+    // 2人対戦用のポート（2人対戦実装の時はこっち）
+    // private string portName = "/dev/cu.m5stack_shibakari_2";
     public int baudRate = 115200;
 
     private SerialPort serialPort;

--- a/Assets/Scripts/SerialReceive.cs
+++ b/Assets/Scripts/SerialReceive.cs
@@ -6,9 +6,9 @@ public class SerialReceive : MonoBehaviour
 {
     public SerialHandler serialHandler;
 
-    private float gyroX, gyroY, gyroZ; // 加速度をpublicで宣言
-    private float accX, accY, accZ; // ジャイロ
+    private float accX, accY, accZ; // 加速度
 
+    private float gyroX, gyroY, gyroZ; // 角速度
     private float pitch, roll, yaw; // 磁気
     private float temp; // 温度
 
@@ -64,22 +64,21 @@ public class SerialReceive : MonoBehaviour
                 temp = float.Parse(tempData);
 
                 // Debug.Logへの表示
-                //Debug.Log($"Received accel data: {accX}, {accY}, {accZ}");
+                // Debug.Log($"Received accel data accX: {accX}, Y:{accY}, Z:{accZ}");
                 // Debug.Logへの表示
                 //Debug.Log($"Received accel data: X:{accX}, Y:{accY}, Z:{accZ}");
 
-
-                // if (accX > 1f)
-                // {
-                //     Flag=1;
-                // }
-                // else if(accX < -1f)
-                // {
-                //     Flag=2;
-                // }else{
-                //     Flag=0;
-                // }
-                //Debug.Log(Flag+"SerialReceive:");
+                // 移動のためのフラッグ
+                if (accX > 1f) {
+                    // 右
+                    Flag=1;
+                } else if(accX < -1f) {
+                    // 左
+                    Flag=2;
+                } else {
+                    // 真ん中
+                    Flag=0;
+                }
             }
             else
             {

--- a/Assets/Scripts/camera.cs
+++ b/Assets/Scripts/camera.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using UnityEngine;
+ 
+public class CameraSample : MonoBehaviour {
+ 
+    private GameObject player;   // プレイヤー情報格納用
+    private Vector3 offset;      // 相対距離取得用
+ 
+    // Use this for initialization
+    void Start () {
+        // Shibakariの情報を取得
+        this.player = GameObject.Find("Shibakari");
+ 
+        // MainCamera(自分自身)とplayerとの相対距離を求める
+        offset = transform.position - player.transform.position;
+
+        // x座標を固定する（-0.3719021に固定）
+        offset.x = -0.3719021f; // float型のリテラルとして表記するためにfを付けます
+    }
+ 
+    // LateUpdate is called after Update each frame
+    void LateUpdate () {
+        // プレイヤーの位置にoffsetを加えた値でカメラの位置を設定する
+        Vector3 newPosition = player.transform.position + offset;
+
+        // xの値を固定するために最初に設定したxの値を代入
+        transform.position = new Vector3(offset.x, newPosition.y, newPosition.z);
+    }
+}

--- a/Assets/Scripts/camera.cs.meta
+++ b/Assets/Scripts/camera.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e1d71fc01a6dd44e6afdd4051344c6e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 概要
- 振った時のオブジェクト（草刈りの刃先）の移動の追加
- 左右に一回ずつ振ったときに前方に10移動

## 変更内容
CutMoveのスクリプトファイル追加
- 切った時のオブジェクト（草刈りの刃先）の移動の処理
- 左右に一回ずつ振った時の前方移動処理

cameraのスクリプトファイル追加
- オブジェクト（草刈りの刃先）の移動に関連するカメラ追従処理

## スクリーンショット
https://github.com/CC-Circle/Shibakari/assets/104050688/6e0484a9-9441-4d1b-a578-71bedc9e0536

## テスト
M5stackがないと確認できないが，移動を確認できる
- PortNameが/dev/cu.m5stack_shibakari_1になっていることに注意

## その他
草のオブジェクトの衝突処理については何も考えていないため，
実装が必要