### PR TITLE
振っているオブジェクト(刈払機)が草に触れた際に草を消すように変更

### DIFF
--- a/Assets/Scripts/CutMove.cs
+++ b/Assets/Scripts/CutMove.cs
@@ -8,9 +8,20 @@ public class CutMove : MonoBehaviour
     private int leftRightCount = 0; // 左右の振りカウント
     private bool wasLeft = false; // 前回が左だったか
 
+    private GameObject objectToDestroy = null;//草に触れたかどうかの判定フラグ
+
+    void OnCollisionEnter(Collision collision)
+    {
+        // 衝突したオブジェクトが "grass" タグを持っているか確認
+        if (collision.gameObject.CompareTag("grass"))
+        {
+            // オブジェクトを消すフラグを立てる
+            objectToDestroy = collision.gameObject;
+        }
+    }
     void Update()
     {
-        Debug.Log(serialReceive.Flag);
+        //Debug.Log(serialReceive.Flag);
         // 現在の位置を取得
         Vector3 currentPosition = transform.position;
 
@@ -44,6 +55,12 @@ public class CutMove : MonoBehaviour
         // 左右に一回ずつ振ったら前進
         if (leftRightCount >= 2)
         {
+            // フラグが立っている場合、オブジェクトを消す
+            if (objectToDestroy != null)
+            {
+                Destroy(objectToDestroy);
+                objectToDestroy = null;
+            }
             currentPosition.z += 10; // 前進させる
             transform.position = currentPosition;
             leftRightCount = 0; // カウントをリセット


### PR DESCRIPTION
## 概要
<!-- このプルリクエストの目的や変更内容を説明してください。 -->
振って進んだ際に、オブジェクト(仮の草)に触れた時そのオブジェクトが消えるように変更

## 関連するIssue
<!-- このプルリクエストに関連するIssueがあれば、その番号を記述してください。 -->

## 変更内容
<!-- 変更の詳細をリストアップしてください。 -->

- [x] 新機能の追加    
- [ ] バグ修正
- [ ] ドキュメントの更新
- [ ] その他（詳細を記述してください）

## スクリーンショット
<!-- 必要に応じて、変更内容を示すスクリーンショットを添付してください。 -->
https://github.com/CC-Circle/Shibakari/assets/135878584/194a5ccc-1a9d-498f-a52a-7534e65adeb3

## レビューのポイント
<!-- レビュワーに対して、特に注目してほしい点やレビューしてほしい箇所を記述してください。 -->

## テスト
<!-- 変更が正しく機能していることを確認するために行ったテスト方法を記述してください。 -->
実行し、M5Stackを動かし、オブジェクトに触れた時にそのオブジェクトが消えるか確認

## その他
<!-- その他、追加で伝えたいことがあればここに記述してください。 -->
現状の軌道では納得いっていないため要検証中